### PR TITLE
feat(openbooks): store library on a volsync-backed PVC

### DIFF
--- a/kubernetes/apps/default/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/default/openbooks/app/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
           - name: envoy-internal
             namespace: networking
     persistence:
-      books:
+      config:
         existingClaim: *app
         globalMounts:
           - path: /books

--- a/kubernetes/apps/default/openbooks/app/helmrelease.yaml
+++ b/kubernetes/apps/default/openbooks/app/helmrelease.yaml
@@ -89,16 +89,6 @@ spec:
             namespace: networking
     persistence:
       books:
-        type: nfs
-        server: nas.internal
-        path: /var/nfs/shared/media
+        existingClaim: *app
         globalMounts:
           - path: /books
-      tmp:
-        type: emptyDir
-        sizeLimit: 1Gi
-        globalMounts:
-          - path: /tmp
-            subPath: tmp
-          - path: /var/log
-            subPath: var-log

--- a/kubernetes/apps/default/openbooks/install.yaml
+++ b/kubernetes/apps/default/openbooks/install.yaml
@@ -9,8 +9,17 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
   interval: 1h
   path: ./kubernetes/apps/default/openbooks/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/openbooks/install.yaml
+++ b/kubernetes/apps/default/openbooks/install.yaml
@@ -19,7 +19,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 10Gi
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
Move the openbooks eBook library off the shared NFS media share onto a dedicated volsync-backed PVC.

## Changes
- `install.yaml`: add the `volsync` component + `dependsOn` + `postBuild.substitute.APP`; set `VOLSYNC_CAPACITY: 10Gi`. Creates a `openbooks` PVC (`openebs-hostpath`, RWO) with an hourly kopia backup to the NFS volsync repo.
- `app/helmrelease.yaml`: `persistence.books` now uses `existingClaim: openbooks` mounted at `/books`, replacing the NFS media mount.

## Notes
- With `--dir /books --persist`, openbooks writes the library under `/books/books` on the PVC.
- On `openebs-hostpath`, `fsGroup: 1000` applies, so the UID-1000 container can write (the NFS approach depended on export permissions).
- 10Gi is a starting size; adjust `VOLSYNC_CAPACITY` if the library grows.